### PR TITLE
chore(gh-actions): Update gh actions to v4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Gradle Wrapper Validation
         uses: gradle/wrapper-validation-action@v1
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Gradle Wrapper Validation
         uses: gradle/wrapper-validation-action@v1
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v2
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Gradle Wrapper Validation
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/actions/wrapper-validation@v4
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,12 +11,12 @@ jobs:
       contents: write
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Gradle Wrapper Validation
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/actions/wrapper-validation@v4
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches

--- a/GravySDK/src/main/java/com/gr4vy/android_sdk/models/CartItem.kt
+++ b/GravySDK/src/main/java/com/gr4vy/android_sdk/models/CartItem.kt
@@ -17,4 +17,5 @@ data class CartItem(
     val productUrl: String? = null,
     val imageUrl: String? = null,
     val categories: List<String>? = null,
-    val productType: String? = null) : Parcelable
+    val productType: String? = null,
+    val sellerCountry: String? = null) : Parcelable

--- a/GravySDK/src/main/java/com/gr4vy/android_sdk/models/Messages.kt
+++ b/GravySDK/src/main/java/com/gr4vy/android_sdk/models/Messages.kt
@@ -165,7 +165,8 @@ data class UpdateCartItem(
     val productUrl: String?,
     val imageUrl: String?,
     val categories: List<String>?,
-    val productType: String?) {
+    val productType: String?,
+    val sellerCountry: String?) {
 
     companion object {
 
@@ -181,7 +182,8 @@ data class UpdateCartItem(
                 productUrl = item.productUrl,
                 imageUrl = item.imageUrl,
                 categories = item.categories,
-                productType = item.productType)
+                productType = item.productType,
+                sellerCountry = item.sellerCountry)
         }
     }
 }


### PR DESCRIPTION
This PR is for updating/fixing the workflow actions versions.

For `gradle/actions/wrapper-validation-action` now its replaced for `gradle/actions/wrapper-validation`. [See release note for v3](https://github.com/gradle/wrapper-validation-action/releases/tag/v3.5.0)