### PR TITLE
chore(gh-actions): Update gh actions to v4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Gradle Wrapper Validation
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/actions/wrapper-validation@v4
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,12 +11,12 @@ jobs:
       contents: write
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Gradle Wrapper Validation
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/actions/wrapper-validation@v4
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches


### PR DESCRIPTION
This PR is for updating/fixing the workflow actions versions.

For `gradle/actions/wrapper-validation-action` now its replaced for `gradle/actions/wrapper-validation`. [See release note for v3](https://github.com/gradle/wrapper-validation-action/releases/tag/v3.5.0)