### PR TITLE
task: expose card details changed event to onEvent handler

### DIFF
--- a/GravySDK/src/main/java/com/gr4vy/android_sdk/models/Gr4vyEvent.kt
+++ b/GravySDK/src/main/java/com/gr4vy/android_sdk/models/Gr4vyEvent.kt
@@ -12,4 +12,11 @@ sealed class Gr4vyEvent : Parcelable, Gr4vyResultEventInterface {
         val status: String,
         val paymentMethodId: String?
     ) : Gr4vyEvent()
+
+    @Parcelize
+    class CardDetailsChanged(
+        val bin: String,
+        val cardType: String,
+        val scheme: String?
+    ): Gr4vyEvent()
 }

--- a/GravySDK/src/main/java/com/gr4vy/android_sdk/models/Messages.kt
+++ b/GravySDK/src/main/java/com/gr4vy/android_sdk/models/Messages.kt
@@ -32,6 +32,13 @@ data class OpenLink(
 )
 
 @Serializable
+data class CardDetailsChanged(
+    @SerialName("bin") val bin: String,
+    @SerialName("cardType") val cardType: String,
+    @SerialName("scheme") val scheme: String?
+)
+
+@Serializable
 sealed class Message
 
 @Serializable
@@ -81,6 +88,13 @@ data class GooglePaySessionAuthorizedMessage(
     val type: String,
     val data: String,
 )
+
+@Serializable
+data class CardDetailsChangedMessage(
+    val type: String,
+    val channel: String,
+    val data: CardDetailsChanged,
+) : Message()
 
 @Serializable
 data class UpdateMessage(

--- a/GravySDK/src/main/java/com/gr4vy/android_sdk/web/MessageHandler.kt
+++ b/GravySDK/src/main/java/com/gr4vy/android_sdk/web/MessageHandler.kt
@@ -63,6 +63,15 @@ class MessageHandler(private val parameters: Parameters, private val isGooglePay
                     }
                 }
             }
+            is CardDetailsChangedMessage -> {
+                return Gr4vyMessageResult(
+                    Gr4vyEvent.CardDetailsChanged(
+                        bin = decodedMessage.data.bin,
+                        cardType = decodedMessage.data.cardType,
+                        scheme = decodedMessage.data.scheme,
+                    )
+                )
+            }
         }
     }
 }

--- a/GravySDK/src/main/java/com/gr4vy/android_sdk/web/MessagePolymorphicSerializer.kt
+++ b/GravySDK/src/main/java/com/gr4vy/android_sdk/web/MessagePolymorphicSerializer.kt
@@ -23,6 +23,7 @@ class MessagePolymorphicSerializer : JsonContentPolymorphicSerializer<Message>(M
             "googlePaySessionStart" -> GoogleStartSessionMessage.serializer()
             "navigation" -> NavigationMessage.serializer()
             "openLink" -> OpenLinkMessage.serializer()
+            "cardDetailsChanged" -> CardDetailsChangedMessage.serializer()
             else -> UnknownMessage.serializer()
         }
     }

--- a/GravySDK/src/test/java/com/gr4vy/android_sdk/web/MessageHandlerTest.kt
+++ b/GravySDK/src/test/java/com/gr4vy/android_sdk/web/MessageHandlerTest.kt
@@ -296,4 +296,32 @@ class MessageHandlerTest : TestCase() {
 
         assertEquals("400", (gr4vyResult as Gr4vyEvent.TransactionFailed).status)
     }
+
+    @Test
+    fun testHandleMessageReturnsCardDetailsChanged() {
+        val expectedBin = "41111111"
+        val expectedCardType = "credit"
+        val expectedScheme = "visa"
+
+        val message =
+            "{" +
+                "\"type\": \"cardDetailsChanged\"," +
+                " \"channel\": \"123\"," +
+                " \"data\": {" +
+                        "\"bin\": \"$expectedBin\"," +
+                        "\"cardType\": \"$expectedCardType\"," +
+                        "\"scheme\": \"$expectedScheme\"" +
+                    "}" +
+            "}"
+
+        val messageHandler = MessageHandler(testParameters)
+
+        val messageHandlerResult = messageHandler.handleMessage(message)
+
+        val gr4vyResult = (messageHandlerResult as Gr4vyMessageResult).result
+
+        assertEquals(expectedBin, (gr4vyResult as Gr4vyEvent.CardDetailsChanged).bin)
+        assertEquals(expectedCardType, (gr4vyResult as Gr4vyEvent.CardDetailsChanged).cardType)
+        assertEquals(expectedScheme, (gr4vyResult as Gr4vyEvent.CardDetailsChanged).scheme)
+    }
 }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Build Status](https://github.com/gr4vy/gr4vy-android/actions/workflows/build.yaml/badge.svg?branch=main)
 
 ![Platforms](https://img.shields.io/badge/Platforms-Android-yellowgreen?style=for-the-badge)
-![Version](https://img.shields.io/badge/Version-1.11.3-yellowgreen?style=for-the-badge)
+![Version](https://img.shields.io/badge/Version-1.12.0-yellowgreen?style=for-the-badge)
 
 Quickly embed Gr4vy in your Android app to store card details, authorize payments, and capture a transaction.
 
@@ -26,7 +26,7 @@ repositories {
 }
 
 dependencies {
-  implementation 'com.github.gr4vy:gr4vy-android:v1.11.3'
+  implementation 'com.github.gr4vy:gr4vy-android:v1.12.0'
 }
 ```
 

--- a/app/src/main/java/com/gr4vy/gr4vy_android_sample/MainActivity.kt
+++ b/app/src/main/java/com/gr4vy/gr4vy_android_sample/MainActivity.kt
@@ -119,6 +119,9 @@ class MainActivity : ComponentActivity(), Gr4vyResultHandler {
             is Gr4vyEvent.TransactionFailed -> {
                 print("Transaction Failed")
             }
+            is Gr4vyEvent.CardDetailsChanged -> {
+                print("Card Details Changed: bin=${event.bin}, cardType=${event.cardType}, scheme=${event.scheme}")
+            }
         }
     }
 }


### PR DESCRIPTION
**Description:** Exposes the new `cardDetailsChanged` event to `onEvent` so merchants can subscribe to it. Also bumps the version to `1.12.0` (will be released separately using that value).

**Ticket:** https://gr4vy.atlassian.net/browse/TA-12031