### PR TITLE
chore: pin GitHub actions to specific commit SHA

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Gradle Wrapper Validation
-        uses: gradle/actions/wrapper-validation@v4
+        uses: gradle/actions/wrapper-validation@48b5f213c81028ace310571dc5ec0fbbca0b2947 # v4
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,12 +11,12 @@ jobs:
       contents: write
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Gradle Wrapper Validation
-        uses: gradle/actions/wrapper-validation@v4
+        uses: gradle/actions/wrapper-validation@48b5f213c81028ace310571dc5ec0fbbca0b2947 # v4
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.gradle/caches
@@ -32,7 +32,7 @@ jobs:
         run: ./gradlew assembleRelease
 
       - name: Create Draft Release with Artifacts
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
         with:
           artifacts: "GravySDK/build/outputs/aar/*.aar"
           draft: true


### PR DESCRIPTION

To proactively limit the impact of a compromised dependency, GitHub recommends that workflows pin dependency versions to a specific commit SHA. This will prevent malicious code added to a new or updated branch or tag from being automatically used.

In GitHub there’s a setting to “Require actions to be pinned to a full-length commit SHA” and we intend to enable this setting soon.

The changes in this PR were created using the [`pin-github-action`](https://github.com/mheap/pin-github-action) tool.


[GitHub blog post](https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/)


<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>